### PR TITLE
A function for checking local port availability

### DIFF
--- a/lib/portscanner.js
+++ b/lib/portscanner.js
@@ -43,6 +43,39 @@ portscanner.findAPortNotInUse = function(startPort, endPort, host, callback) {
 }
 
 /**
+ * Finds the first port with a status of 'closed', implying the port is not in
+ * use, additionally attempting to establish a listening socket (local only).
+ * Wraps `findAPortWithStatus` until it finds one that is free.
+ *
+ * @param {Number} startPort  - Port to begin status check on (inclusive).
+ * @param {Number} endPort    - Last port to check status on (inclusive).
+ *                              Defaults to 65535.
+ * @param {Function} callback - function (error, port) { ... }
+ *   - {Object|null} error    - Any errors that occurred while port scanning.
+ *   - {Number|Boolean} port  - The first closed port found. Note, this is the
+ *                              first port that returns status as 'closed', not
+ *                              necessarily the first closed port checked. If no
+ *                              closed port is found, the value is false.
+ */
+portscanner.findALocalPortNotInUse = function(startPort, endPort, callback){
+  findAPortWithStatus('closed', startPort, endPort, '127.0.0.1', function(err, port){
+    var server = net.createServer();
+    server.listen(port);
+    server.on('error', function (e) {
+      if (e.code == 'EADDRINUSE') {
+        portscanner.findLocalPortNotInUse(port, endPort, callback);
+      }else{
+        callback(e);
+      }
+    });
+    server.on('listening', function(e) {
+     server.close();
+     callback(null, port);
+    });
+  });
+}
+
+/**
  * Checks the status of an individual port.
  *
  * @param {Number} port       - Port to check status on.


### PR DESCRIPTION
This local-only function has the additional check of establishing
a listening socket on the intended port to check availability, which
is destroyed as soon as it is in listening status.

This solved  an issue I was having where a port established by SSH was being returned as 'open' by portscanner, i.e:

```
root     43716     1  0 Nov06 ?        00:00:00 ssh -L 0.0.0.0:35005:192.168.3.218:4101 -f stackato@localhost -N -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no 

```
