### PR TITLE
Better timeout handling for checkPortStatus

### DIFF
--- a/lib/portscanner.js
+++ b/lib/portscanner.js
@@ -45,15 +45,26 @@ portscanner.findAPortNotInUse = function(startPort, endPort, host, callback) {
 /**
  * Checks the status of an individual port.
  *
- * @param {Number} port       - Port to check status on.
- * @param {String} host       - Where to scan. Defaults to 'localhost'.
- * @param {Function} callback - function (error, port) { ... }
- *   - {Object|null} error    - Any errors that occurred while port scanning.
- *   - {String} status        - 'open' if the port is in use.
- *                              'closed' if the port is available.
+ * @param {Number} port           - Port to check status on.
+ * @param {String|Object} options - host or options
+ *   - {String} host              - Host of where to scan. Defaults to 'localhost'.
+ *   - {Object} options
+ *     - {String} host            - Host of where to scan. Defaults to 'localhost'.
+ *     - {Number} timeout         - Connection timeout. Defaults to 400ms.
+ * @param {Function} callback     - function (error, port) { ... }
+ *   - {Object|null} error        - Any errors that occurred while port scanning.
+ *   - {String} status            - 'open' if the port is in use.
+ *                                  'closed' if the port is available.
  */
-portscanner.checkPortStatus = function(port, host, callback) {
-  host = host || 'localhost'
+portscanner.checkPortStatus = function(port, options, callback) {
+  if (typeof options === 'string') {
+    // Assume this param is the host option
+    options = {host: options}
+  }
+
+  var host = options.host || 'localhost'
+  var timeout = options.timeout || 400
+
   var socket = new Socket()
     , status = null
     , error = null
@@ -65,7 +76,6 @@ portscanner.checkPortStatus = function(port, host, callback) {
   })
 
   // If no response, assume port is not listening
-  timeout = 400
   socket.setTimeout(timeout)
   socket.on('timeout', function() {
     status = 'closed'


### PR DESCRIPTION
I ran into an issue where the system resources on a dev machine were stretched and memcached took longer than 400ms to respond. If I waited for longer, it would successfully respond in this situation.

I think that the default timeout should be bumped to about 1000ms. It would also be nice if you could pass in an override value, but I didn't want to change the signature without asking how you'd prefer to see that done. I prefer that required params are params and options params are a object, like so:

``` javascript
portscanner.checkPortStatus = function(port, options, callback) {
  var host = options.host || 'localhost';
  var timeout = options.timeout || 1000;
  // ...
```

I also exposed the possible exceptions to the callback. I found this made debugging the issue much easier.
