### PR TITLE
Update portscanner.js

### DIFF
--- a/lib/portscanner.js
+++ b/lib/portscanner.js
@@ -117,7 +117,7 @@ function findAPortWithStatus(status, startPort, endPort, host, callback) {
       numberOfPortsChecked++
       if (statusOfPort === status) {
         foundPort = true
-        callback(null, port)
+        callback(error, port)
       }
       else if (error) {
         callback(error)


### PR DESCRIPTION
In the code, a timeout while checking a port throws an error. This error gets included in the async call back and end the loop. But if your are checking for closed status this is a good thing and not an error...the port is good to go!

I flipped the order of the checks...sometime we don't care about an error if the status matches.  In the case of looking for an port not in use we actually want the timeout to trip.

There may be a better way of doing this but for now it is making findAPortNotInUse work for me.
