### PR TITLE
fix port reporting

### DIFF
--- a/example/portscan.js
+++ b/example/portscan.js
@@ -3,33 +3,33 @@ var http        = require('http')
 
 // Sets up an HTTP server listening on port 3005
 var server = http.createServer(function (request, response) {
-
 })
-server.listen(3005, '127.0.0.1', function() {
 
+server.listen(3005, '127.0.0.1', function() {
   // Checks the status of an individual port.
   portscanner.checkPortStatus(3005, '127.0.0.1', function(error, status) {
     // Status should be 'open' since the HTTP server is listening on that port
     console.log('Status at port 3005 is ' + status)
+    if (error) console.error(error);
   })
-
   portscanner.checkPortStatus(3000, '127.0.0.1', function(error, status) {
     // Status should be 'closed' since no service is listening on that port.
     console.log('Status at port 3000 is ' + status)
+    if (error) console.error(error);
   })
 
   // Finds a port that a service is listening on
   portscanner.findAPortInUse(3000, 3010, '127.0.0.1', function(error, port) {
     // Port should be 3005 as the HTTP server is listening on that port
     console.log('Found an open port at ' + port)
+    if (error) console.error(error);
   })
-
   // Finds a port no service is listening on
   portscanner.findAPortNotInUse(3000, 3010, '127.0.0.1', function(error, port) {
     // Will return any number between 3000 and 3010 (inclusive), that's not 3005.
     // The order is unknown as the port status checks are asynchronous.
     console.log('Found a closed port at ' + port)
+    if (error) console.error(error);
   })
-
 })
 

--- a/lib/portscanner.js
+++ b/lib/portscanner.js
@@ -91,8 +91,7 @@ portscanner.checkPortStatus = function(port, options, callback) {
   })
 
   // Return after the socket has closed
-  socket.on('close', function(exception) {
-    if (exception) error = exception
+  socket.on('close', function() {
     callback(error, status)
   })
 
@@ -117,14 +116,11 @@ function findAPortWithStatus(status, startPort, endPort, host, callback) {
       numberOfPortsChecked++
       if (statusOfPort === status) {
         foundPort = true
-        callback(error, port)
-      }
-      else if (error) {
         callback(error)
       }
       else {
         port++
-        callback(null, false)
+        callback(null)
       }
     })
   }
@@ -133,7 +129,7 @@ function findAPortWithStatus(status, startPort, endPort, host, callback) {
   // found or the range of ports has been exhausted
   async.until(hasFoundPort, checkNextPort, function(error) {
     if (error) {
-      callback(error)
+      callback(error, port)
     }
     else if (foundPort) {
       callback(null, port)


### PR DESCRIPTION
This fixes an issue where the found port was not reported properly. The output from the examples now looks like:

``` bash
$ node example/portscan.js 
Found a closed port at 3000
{ [Error: connect ECONNREFUSED]
  code: 'ECONNREFUSED',
  errno: 'ECONNREFUSED',
  syscall: 'connect' }
Status at port 3000 is closed
{ [Error: connect ECONNREFUSED]
  code: 'ECONNREFUSED',
  errno: 'ECONNREFUSED',
  syscall: 'connect' }
Status at port 3005 is open
Found an open port at 3005
```

This fixes https://github.com/baalexander/node-portscanner/issues/15
