### PR TITLE
Use socket.destroy() not socket.end() on successful connection

### DIFF
--- a/lib/portscanner.js
+++ b/lib/portscanner.js
@@ -72,7 +72,7 @@ portscanner.checkPortStatus = function(port, options, callback) {
   // Socket connection established, port is open
   socket.on('connect', function() {
     status = 'open'
-    socket.end()
+    socket.destroy()
   })
 
   // If no response, assume port is not listening


### PR DESCRIPTION
When socket.end() is called, a FIN packet is sent however if the other host does not respond the socket will timeout and so this module will report 'closed'. The port is open but the other host is misbehaving.

This fix just forces the connection to be destroyed immediately and so means that a successful connection will always result in an 'open' status being reported.
