### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,10 +34,5 @@
     "node": ">=0.4",
     "npm": ">=1.0.0"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/baalexander/node-portscanner/raw/master/LICENSE"
-    }
-  ]
+  "license": "MIT"
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/