### PR TITLE
Accept ports as strings

### DIFF
--- a/lib/portscanner.js
+++ b/lib/portscanner.js
@@ -1,6 +1,7 @@
 var net = require('net')
 var Socket = net.Socket
 var async = require('async')
+var isNumberLike = require('is-number-like')
 var promisify = require('./promisify')
 
 /**
@@ -153,14 +154,14 @@ function findAPortWithStatus (status) {
 
   params = [].slice.call(arguments, 1)
 
-  if (typeof params[0] === 'number') {
-    startPort = params[0]
+  if (isNumberLike(params[0])) {
+    startPort = parseInt(params[0], 10)
   } else if (params[0] instanceof Array) {
     portList = params[0]
   }
 
-  if (typeof params[1] === 'number') {
-    endPort = params[1]
+  if (isNumberLike(params[2])) {
+    endPort = parseInt(params[1], 10)
   } else if (typeof params[1] === 'string') {
     host = params[1]
   } else if (typeof params[1] === 'function') {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   },
   "main": "./lib/portscanner.js",
   "dependencies": {
-    "async": "1.5.2"
+    "async": "1.5.2",
+    "is-number-like": "^1.0.3"
   },
   "devDependencies": {
     "ava": "^0.4.2",

--- a/test.js
+++ b/test.js
@@ -230,3 +230,66 @@ test('findAPortNotInUse - ports in reverse order, highest one being in use', t =
     t.is(port, 2995)
   })
 })
+
+test('checkPortStatus - taken (port as a string)', t => {
+  t.plan(2)
+
+  portScanner.checkPortStatus('3000', '127.0.0.1', (error, port) => {
+    t.is(error, null)
+    t.is(port, 'open')
+  })
+})
+
+test('checkPortStatus - taken (without host) (port as a string)', t => {
+  t.plan(2)
+
+  portScanner.checkPortStatus('3000', (error, port) => {
+    t.is(error, null)
+    t.is(port, 'open')
+  })
+})
+
+test('checkPortStatus - free (port as a string)', t => {
+  t.plan(2)
+
+  portScanner.checkPortStatus('3001', '127.0.0.1', (error, port) => {
+    t.is(error, null)
+    t.is(port, 'closed')
+  })
+})
+
+test('checkPortStatus - free (without host) (port as a string)', t => {
+  t.plan(2)
+
+  portScanner.checkPortStatus('3001', (error, port) => {
+    t.is(error, null)
+    t.is(port, 'closed')
+  })
+})
+
+test('findPortInUse - taken port in range (startPort as a string)', t => {
+  t.plan(2)
+
+  portScanner.findAPortInUse('2990', 3010, '127.0.0.1', (error, port) => {
+    t.is(error, null)
+    t.is(port, 2999)
+  })
+})
+
+test('findPortInUse - taken port in range (endPort as a string)', t => {
+  t.plan(2)
+
+  portScanner.findAPortInUse(2990, '3010', '127.0.0.1', (error, port) => {
+    t.is(error, null)
+    t.is(port, 2999)
+  })
+})
+
+test('findPortInUse - taken port in range (startPort and endPort as strings)', t => {
+  t.plan(2)
+
+  portScanner.findAPortInUse('3000', '3010', '127.0.0.1', (error, port) => {
+    t.is(error, null)
+    t.is(port, 3000)
+  })
+})


### PR DESCRIPTION
Uses [`is-number-like`](https://www.npmjs.com/package/is-number-like) instead of `typeof xx === 'number'` to check arguments for ports.

Enables passing ports as strings.

Fixes #52