### PR TITLE
isNumberLike fix

### DIFF
--- a/lib/portscanner.js
+++ b/lib/portscanner.js
@@ -154,18 +154,18 @@ function findAPortWithStatus (status) {
 
   params = [].slice.call(arguments, 1)
 
-  if (isNumberLike(params[0])) {
-    startPort = parseInt(params[0], 10)
-  } else if (params[0] instanceof Array) {
+  if (params[0] instanceof Array) {
     portList = params[0]
+  } else if (isNumberLike(params[0])) {
+    startPort = parseInt(params[0], 10)
   }
 
-  if (isNumberLike(params[2])) {
-    endPort = parseInt(params[1], 10)
+  if (typeof params[1] === 'function') {
+    callback = params[1]
   } else if (typeof params[1] === 'string') {
     host = params[1]
-  } else if (typeof params[1] === 'function') {
-    callback = params[1]
+  } else if (isNumberLike(params[1])) {
+    endPort = parseInt(params[1], 10)
   }
 
   if (typeof params[2] === 'string') {


### PR DESCRIPTION
It seems `isNumberLike` throws in some cases 

 - array [x,x]
 - function(x, x){}

This fixes it by checking for those cases before checking for `isNumberLike`.

([is-number-like#1](https://github.com/vigour-io/is-number-like/issues/1))

Also a params index was wrong.

