### PR TITLE
fix: options behaviour in `findAPortNotInUse` and `findAPortInUse`

### DIFF
--- a/lib/portscanner.js
+++ b/lib/portscanner.js
@@ -150,7 +150,7 @@ function checkPortStatus (port) {
  * @param {...params} params - Params as passed exactly to {@link findAPortInUse} and {@link findAPortNotInUse}.
  */
 function findAPortWithStatus (status) {
-  var params, startPort, endPort, portList, host, callback
+  var params, startPort, endPort, portList, host, opts, callback
 
   params = [].slice.call(arguments, 1)
 
@@ -164,12 +164,16 @@ function findAPortWithStatus (status) {
     callback = params[1]
   } else if (typeof params[1] === 'string') {
     host = params[1]
+  } else if (typeof params[1] === 'object') {
+    opts = params[1]
   } else if (isNumberLike(params[1])) {
     endPort = parseInt(params[1], 10)
   }
 
   if (typeof params[2] === 'string') {
     host = params[2]
+  } else if (typeof params[2] === 'object') {
+    opts = params[2]
   } else if (typeof params[2] === 'function') {
     callback = params[2]
   }
@@ -179,6 +183,10 @@ function findAPortWithStatus (status) {
   }
 
   if (!callback) return promisify(findAPortWithStatus, arguments)
+
+  opts = opts || {}
+
+  host = host || opts.host
 
   if (startPort && endPort && endPort < startPort) {
     // WARNING: endPort less than startPort. Using endPort as startPort & vice versa.
@@ -201,7 +209,7 @@ function findAPortWithStatus (status) {
 
   // Checks the status of the port
   var checkNextPort = function (callback) {
-    checkPortStatus(port, host, function (error, statusOfPort) {
+    checkPortStatus(port, host, opts, function (error, statusOfPort) {
       numberOfPortsChecked++
       if (statusOfPort === status) {
         foundPort = true

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "portscanner",
   "description": "Asynchronous port scanner for Node.js",
   "scripts": {
+    "coverage": "nyc npm run test",
     "test": "ava",
     "lint": "standard"
   },
@@ -31,11 +32,12 @@
   },
   "main": "./lib/portscanner.js",
   "dependencies": {
-    "async": "1.5.2",
+    "async": "^2.6.0",
     "is-number-like": "^1.0.3"
   },
   "devDependencies": {
     "ava": "^0.4.2",
+    "nyc": "^11.3.0",
     "eslint": "^3.10.2",
     "eslint-config-standard": "^6.2.1",
     "standard": "^8.5.0"

--- a/test.js
+++ b/test.js
@@ -30,6 +30,22 @@ function checkPortStatus () {
       t.is(port, 'open')
     })
   })
+  test('checkPortStatus - taken (with host in options)', t => {
+    t.plan(2)
+
+    portScanner.checkPortStatus(3000, { host: '127.0.0.1' }, (error, port) => {
+      t.is(error, null)
+      t.is(port, 'open')
+    })
+  })
+  test('checkPortStatus - taken (with host as string and options)', t => {
+    t.plan(2)
+
+    portScanner.checkPortStatus(3000, '127.0.0.1', { timeout: 400 }, (error, port) => {
+      t.is(error, null)
+      t.is(port, 'open')
+    })
+  })
   test('checkPortStatus - taken (without host)', t => {
     t.plan(2)
 
@@ -46,6 +62,22 @@ function checkPortStatus () {
       t.is(port, 'closed')
     })
   })
+  test('checkPortStatus - free (with host in options argument)', t => {
+    t.plan(2)
+
+    portScanner.checkPortStatus(3001, { host: '127.0.0.1' }, (error, port) => {
+      t.is(error, null)
+      t.is(port, 'closed')
+    })
+  })
+  test('checkPortStatus - free (with host as string and options)', t => {
+    t.plan(2)
+
+    portScanner.checkPortStatus(3001, '127.0.0.1', { timeout: 400 }, (error, port) => {
+      t.is(error, null)
+      t.is(port, 'closed')
+    })
+  })
   test('checkPortStatus - free (without host)', t => {
     t.plan(2)
 
@@ -54,10 +86,25 @@ function checkPortStatus () {
       t.is(port, 'closed')
     })
   })
+  test('checkPortStatus - timeout', t => {
+    t.plan(2)
+
+    portScanner.checkPortStatus(3001, { host: '127.0.0.1', timeout: 1 }, (error, port) => {
+      t.is(error, null)
+      t.is(port, 'closed')
+    })
+  })
+  test('checkPortStatus - error', t => {
+    t.plan(1)
+
+    portScanner.checkPortStatus(3001, '127.0.0.0', (error, port) => {
+      t.is(error.code, 'ENETUNREACH')
+    })
+  })
 }
 
 function findPortInUse () {
-  test('findPortInUse - taken port in range', t => {
+  test('findAPortInUse - taken port in range', t => {
     t.plan(2)
 
     portScanner.findAPortInUse(3000, 3010, '127.0.0.1', (error, port) => {
@@ -65,7 +112,7 @@ function findPortInUse () {
       t.is(port, 3000)
     })
   })
-  test('findPortInUse - taken port in range (without host)', t => {
+  test('findAPortInUse - taken port in range (without host)', t => {
     t.plan(2)
 
     portScanner.findAPortInUse(3000, 3010, (error, port) => {
@@ -73,7 +120,15 @@ function findPortInUse () {
       t.is(port, 3000)
     })
   })
-  test('findPortInUse - taken port in range (without endPort)', t => {
+  test('findAPortInUse - taken port in range (with host in options)', t => {
+    t.plan(2)
+
+    portScanner.findAPortInUse(3000, 3010, { host: '127.0.0.1' }, (error, port) => {
+      t.is(error, null)
+      t.is(port, 3000)
+    })
+  })
+  test('findAPortInUse - taken port in range (without endPort)', t => {
     t.plan(2)
 
     portScanner.findAPortInUse(3000, '127.0.0.1', (error, port) => {
@@ -81,7 +136,7 @@ function findPortInUse () {
       t.is(port, 3000)
     })
   })
-  test('findPortInUse - taken port in range (without endPort and host) ', t => {
+  test('findAPortInUse - taken port in range (without endPort and host) ', t => {
     t.plan(2)
 
     portScanner.findAPortInUse(3000, (error, port) => {
@@ -89,7 +144,15 @@ function findPortInUse () {
       t.is(port, 3000)
     })
   })
-  test('findPortInUse - taken port in range - ports as array', t => {
+  test('findAPortInUse - taken port in range (without endPort and host in options)', t => {
+    t.plan(2)
+
+    portScanner.findAPortInUse(3000, { host: '127.0.0.1' }, (error, port) => {
+      t.is(error, null)
+      t.is(port, 3000)
+    })
+  })
+  test('findAPortInUse - taken port in range - ports as array', t => {
     t.plan(2)
 
     portScanner.findAPortInUse([2999, 3000, 3001], '127.0.0.1', (error, port) => {
@@ -97,7 +160,15 @@ function findPortInUse () {
       t.is(port, 2999)
     })
   })
-  test('findPortInUse - taken port in range - ports as array (without host)', t => {
+  test('findAPortInUse - taken port in range - ports as array', t => {
+    t.plan(2)
+
+    portScanner.findAPortInUse([2999, 3000, 3001], '127.0.0.1', (error, port) => {
+      t.is(error, null)
+      t.is(port, 2999)
+    })
+  })
+  test('findAPortInUse - taken port in range - ports as array (without host)', t => {
     t.plan(2)
 
     portScanner.findAPortInUse([2999, 3000, 3001], (error, port) => {
@@ -105,7 +176,15 @@ function findPortInUse () {
       t.is(port, 2999)
     })
   })
-  test('findPortInUse - all ports in range free', t => {
+  test('findAPortInUse - taken port in range - ports as array (with host on options)', t => {
+    t.plan(2)
+
+    portScanner.findAPortInUse([2999, 3000, 3001], { host: '127.0.0.1' }, (error, port) => {
+      t.is(error, null)
+      t.is(port, 2999)
+    })
+  })
+  test('findAPortInUse - all ports in range free', t => {
     t.plan(2)
 
     portScanner.findAPortInUse(3001, 3010, '127.0.0.1', (error, port) => {
@@ -113,7 +192,7 @@ function findPortInUse () {
       t.false(port)
     })
   })
-  test('findPortInUse - all ports in range free - ports as array', t => {
+  test('findAPortInUse - all ports in range free - ports as array', t => {
     t.plan(2)
 
     portScanner.findAPortInUse([3001, 3005, 3008], '127.0.0.1', (error, port) => {
@@ -121,13 +200,34 @@ function findPortInUse () {
       t.false(port)
     })
   })
-  test('findPortInUse - all ports in range free - ports as array (without host)', t => {
+  test('findAPortInUse - all ports in range free - ports as array (with host in options)', t => {
+    t.plan(2)
+
+    portScanner.findAPortInUse([3001, 3005, 3008], { host: '127.0.0.1' }, (error, port) => {
+      t.is(error, null)
+      t.false(port)
+    })
+  })
+  test('findAPortInUse - all ports in range free - ports as array (without host)', t => {
     t.plan(2)
 
     portScanner.findAPortInUse([3001, 3005, 3008], (error, port) => {
       t.is(error, null)
       t.false(port)
     })
+  })
+  test('findAPortInUse - no promise in env', t => {
+    t.plan(1)
+
+    var oldPromise = Promise
+
+    // eslint-disable-next-line
+    Promise = undefined
+
+    t.throws(() => portScanner.findAPortInUse(3001, 3010, { host: '127.0.0.1' }))
+
+    // eslint-disable-next-line
+    Promise = oldPromise
   })
 }
 
@@ -148,10 +248,26 @@ function findPortNotInUse () {
       t.is(port, 3001)
     })
   })
+  test('findAPortNotInUse - start from taken port (with host in options)', t => {
+    t.plan(2)
+
+    portScanner.findAPortNotInUse(3000, 3010, { host: '127.0.0.1' }, (error, port) => {
+      t.is(error, null)
+      t.is(port, 3001)
+    })
+  })
   test('findAPortNotInUse - all ports in range taken', t => {
     t.plan(2)
 
     portScanner.findAPortNotInUse(2999, 3000, '127.0.0.1', (error, port) => {
+      t.is(error, null)
+      t.false(port)
+    })
+  })
+  test('findAPortNotInUse - all ports in range taken (with host in options)', t => {
+    t.plan(2)
+
+    portScanner.findAPortNotInUse(2999, 3000, { host: '127.0.0.1' }, (error, port) => {
       t.is(error, null)
       t.false(port)
     })
@@ -163,6 +279,27 @@ function findPortNotInUse () {
       t.is(error, null)
       t.is(port, 3002)
     })
+  })
+  test('findAPortNotInUse - with array as parameter (with host in options)', t => {
+    t.plan(2)
+
+    portScanner.findAPortNotInUse([3000, 3002, 2999], { host: '127.0.0.1' }, (error, port) => {
+      t.is(error, null)
+      t.is(port, 3002)
+    })
+  })
+  test('findAPortNotInUse - promise (error) (no promise in env)', t => {
+    t.plan(1)
+
+    var oldPromise = Promise
+
+    // eslint-disable-next-line
+    Promise = undefined
+
+    t.throws(() => portScanner.findAPortNotInUse(3001, 3010, { host: '127.0.0.1' }))
+
+    // eslint-disable-next-line
+    Promise = oldPromise
   })
 }
 
@@ -181,6 +318,13 @@ function promise () {
       t.is(port, 3001)
     })
   })
+  test('findAPortNotInUse - promise (with host in options)', t => {
+    t.plan(1)
+
+    portScanner.findAPortNotInUse(3000, 3010, { host: '127.0.0.1' }).then(port => {
+      t.is(port, 3001)
+    })
+  })
   test('findAPortNotInUse - promise (without host and endPort)', t => {
     t.plan(1)
 
@@ -195,10 +339,24 @@ function promise () {
       t.is(port, 3000)
     })
   })
+  test('findAPortInUse - promise (with host in options)', t => {
+    t.plan(1)
+
+    portScanner.findAPortInUse(3000, 3010, { host: '127.0.0.1' }).then(port => {
+      t.is(port, 3000)
+    })
+  })
   test('findAPortInUse - promise (error)', t => {
     t.plan(1)
 
     portScanner.findAPortInUse(3001, 3010, '127.0.0.1').catch(err => {
+      t.not(err, null)
+    })
+  })
+  test('findAPortInUse - promise (error) (with host in options)', t => {
+    t.plan(1)
+
+    portScanner.findAPortInUse(3001, 3010, { host: '127.0.0.1' }).catch(err => {
       t.not(err, null)
     })
   })


### PR DESCRIPTION
@laggingreflex 
Include:
1. Fix options behaviour in `findAPortNotInUse` and `findAPortInUse`
2. Improve tests and increase coverage (`99.07%`)
3. Update `async` to latest (import perf)