### PR TITLE
feat: add dont-break

### DIFF
--- a/.dont-break.json
+++ b/.dont-break.json
@@ -1,0 +1,4 @@
+[
+  "https://github.com/BrowserSync/browser-sync",
+  "https://github.com/gruntjs/grunt-contrib-connect"
+]

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "portscanner",
   "description": "Asynchronous port scanner for Node.js",
   "scripts": {
-    "test": "ava",
+    "test": "ava && dont-break",
     "lint": "standard"
   },
   "keywords": [
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "ava": "^0.4.2",
+    "dont-break": "^1.13.4",
     "eslint": "^3.10.2",
     "eslint-config-standard": "^6.2.1",
     "standard": "^8.5.0"


### PR DESCRIPTION
Adds [dont-break] with [browser-sync] and [grunt-contrib-connect], which are 2 of the [most popular dependents] of this project.

Fixes #58

[dont-break]: https://github.com/bahmutov/dont-break
[browser-sync]: https://github.com/BrowserSync/browser-sync
[grunt-contrib-connect]: https://github.com/gruntjs/grunt-contrib-connect
[most popular dependents]: https://www.npmjs.com/browse/depended/portscanner